### PR TITLE
Update API authefication method for Bitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ s.google('http://www.google.com', 'key', function(result) {
   console.log(result);
 });
 
-s.bitly('http://bit.ly', 'user', 'key', 'json', function(result) {
+s.bitly('http://bit.ly', 'key', 'json', function(result) {
     console.log(result);
 });
 ```

--- a/lib/shortener.js
+++ b/lib/shortener.js
@@ -33,12 +33,12 @@ Shortener.prototype.google = function(longurl, key, callback) {
   req.end();
 };
 
-Shortener.prototype.bitly = function(longurl, user, key, format, callback) {
+Shortener.prototype.bitly = function(longurl, key, format, callback) {
   var options = {
     host: 'api-ssl.bitly.com',
     port: 443,
-    path: '/v3/shorten?login=' + user + 
-      '&apikey=' + key + 
+    path: '/v3/shorten?' +
+      '&access_token=' + key + 
       '&longUrl=' + longurl + 
       '&format=' + format,
     method: 'GET'

--- a/sample.js
+++ b/sample.js
@@ -16,10 +16,9 @@ var s = new shortener.Shortener();
 // bit.ly
 (function() {
   var url = 'http://bit.ly';
-  var user = 'USER';
   var key = 'KEY';
   var format = 'json';
-  s.bitly(url, user, key, format, function(result) {
+  s.bitly(url, key, format, function(result) {
     console.log(result);
     if (result['status_code'] === 200 && result['status_txt'] === 'OK') {
       console.log(result['data']['url']);

--- a/test/shortener_test.js
+++ b/test/shortener_test.js
@@ -18,11 +18,10 @@ exports['urlshorener goo.gle'] = function (test) {
 
 exports['urlshorener bit.ly'] = function (test) {
   var url = 'http://bit.ly';
-  var user = 'USER';
   var key = 'KEY';
   var format = 'json';
 	var s = new shortener.Shortener();
-	s.bitly(url, user, key, format, function(result) {
+	s.bitly(url, key, format, function(result) {
 		test.deepEqual(result
                    , { status_code: 200,
                        status_txt: 'OK',


### PR DESCRIPTION
API key method is deprecated, see [documentation](http://dev.bitly.com/authentication.html#apikey).
Update library, tests, sample file and readme.
